### PR TITLE
Only hide dropzone when no files have been uploaded

### DIFF
--- a/web_src/js/features/repo-issue.ts
+++ b/web_src/js/features/repo-issue.ts
@@ -542,7 +542,11 @@ function initIssueTemplateCommentEditors(commentForm: HTMLFormElement) {
       // deactivate all markdown editors
       showElem(commentForm.querySelectorAll('.combo-editor-dropzone .form-field-real'));
       hideElem(commentForm.querySelectorAll('.combo-editor-dropzone .combo-markdown-editor'));
-      hideElem(commentForm.querySelectorAll('.combo-editor-dropzone .form-field-dropzone'));
+      queryElems(commentForm, '.combo-editor-dropzone .form-field-dropzone', (dropzoneContainer) => {
+        const dropzone = dropzoneContainer.closest('.combo-editor-dropzone')?.querySelector('.dropzone');
+        const hasUploadedFiles = dropzone?.querySelector('.dz-preview') !== null;
+        if (!hasUploadedFiles) hideElem(dropzoneContainer);
+      });
 
       // activate this markdown editor
       hideElem(fieldTextarea);


### PR DESCRIPTION
Instead of always hiding the dropzone when it's not active, hide it when when there are no uploaded files, or never hide it when there are uploaded files.

Fixes #35125 
